### PR TITLE
Risolto problema di compatibilità con l'ultima versione di JQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
 
 	<!-- JS in fondo per caricamento rapido della pagina -->
 	<!-- Importo prima JQuery e il plugin -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+	<script src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+        crossorigin="anonymous"></script>
 	<script src="js/jquery.crossword.js"></script>
 
 	<!-- Importo lo script -->

--- a/js/jquery.crossword.js
+++ b/js/jquery.crossword.js
@@ -244,7 +244,7 @@
 						var letters = puzz.data[x-1].answer.split('');
 
 						for (var i=0; i < entries[x-1].length; ++i) {
-							light = $(puzzCells +'[data-coords="' + entries[x-1][i] + '"]');
+							light = $('td[data-coords="' + entries[x-1][i] + '"]');
 							
 							// check if POSITION property of the entry on current go-round is same as previous. 
 							// If so, it means there's an across & down entry for the position.
@@ -462,7 +462,7 @@
 					
 						util.getActivePositionFromClassGroup(e.target);
 						
-						clue = $(clueLiEls + '[data-position=' + activePosition + ']');
+						clue = $('li.clue[data-position=' + activePosition + ']');
 						activeClueIndex = $(clueLiEls).index(clue);
 						
 						currOri = clue.parent().prop('class');
@@ -493,10 +493,10 @@
 				highlightClue: function() {
 					var clue;				
 					$('.clues-active').removeClass('clues-active');
-					$(clueLiEls + '[data-position=' + activePosition + ']').addClass('clues-active');
+					$('li.clue[data-position=' + activePosition + ']').addClass('clues-active');
 					
 					if (mode === 'interacting') {
-						clue = $(clueLiEls + '[data-position=' + activePosition + ']');
+						clue = $('li.clue[data-position=' + activePosition + ']');
 						activeClueIndex = $(clueLiEls).index(clue);
 					};
 				},
@@ -525,8 +525,8 @@
 
 						if(classes.length > 1){
 							// get orientation for each reported position
-							e1Ori = $(clueLiEls + '[data-position=' + classes[0].split('-')[1] + ']').parent().prop('id');
-							e2Ori = $(clueLiEls + '[data-position=' + classes[1].split('-')[1] + ']').parent().prop('id');
+							e1Ori = $('li.clue[data-position=' + classes[0].split('-')[1] + ']').parent().prop('id');
+							e2Ori = $('li.clue[data-position=' + classes[1].split('-')[1] + ']').parent().prop('id');
 
 							// test if clicked input is first in series. If so, and it intersects with
 							// entry of opposite orientation, switch to select this one instead


### PR DESCRIPTION
Il plugin ora **DOVREBBE** funzionare sia con la versione per la quale era stato pensato ([JQuery 1.6.2](https://blog.jquery.com/2011/06/30/jquery-162-released/)) sia con la più recente, che al momento è [JQuery 3.5.3](http://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/).

In caso di qualsiasi problema aprite un _Issue_ o risolvete voi tramite una _Pull Request_.